### PR TITLE
Fix voice assistant reliability and add website action execution

### DIFF
--- a/Backend/SpeechAssistant/agent.py
+++ b/Backend/SpeechAssistant/agent.py
@@ -6,18 +6,16 @@ from livekit.plugins import (
 )
 from livekit.plugins import google
 from prompts import AGENT_INSTRUCTION, SESSION_INSTRUCTION
-from tools import make_search_products, make_list_top_search_results, make_add_to_cart, make_view_cart, make_place_order
+from memory import MemoryStore
+from tools import (
+    make_search_products,
+    make_list_top_search_results,
+    make_add_to_cart,
+    make_view_cart,
+    make_place_order,
+    make_website_action,
+)
 load_dotenv()
-
-class MemoryStore:
-    def __init__(self):
-        self.store = {}
-
-    def set(self, key, value):
-        self.store[key] = value
-
-    def get(self, key, default=None):
-        return self.store.get(key, default)
 
 
 class Assistant(Agent):
@@ -35,6 +33,7 @@ class Assistant(Agent):
                 make_add_to_cart(self.memory),
                 make_view_cart(self.memory),
                 make_place_order(self.memory),
+                make_website_action(self.memory),
             ],
         )
         
@@ -44,6 +43,8 @@ async def entrypoint(ctx: agents.JobContext):
     session = AgentSession(
         
     )
+
+    await ctx.connect()
 
     await session.start(
         room=ctx.room,
@@ -56,8 +57,6 @@ async def entrypoint(ctx: agents.JobContext):
             noise_cancellation=noise_cancellation.BVC(),
         ),
     )
-
-    await ctx.connect()
 
     await session.generate_reply(
         instructions=SESSION_INSTRUCTION,

--- a/Backend/SpeechAssistant/prompts.py
+++ b/Backend/SpeechAssistant/prompts.py
@@ -53,11 +53,16 @@ You are a personal Assistant called Rose who will help with only shopping purpos
     2. The 'view_cart' tool shows the list of items in the cart, total cost, and any delivery charges.
     3. While viewing the cart the delivery charge is always 5 dollars if the items in the cart totals to less than 50 dollars only.
 
--'place_order':
+ -'place_order':
    1. Use this tool when the user asks to place the order, complete the purchase, or checkout.
    2. It will automatically clear the cart after order placement.
    3. Example triggers: "Place order", "Checkout", "Buy these", "Complete purchase".
    4. You should strictly follow the reply format mentioned in the tool and do not reply on your own.
+
+ -'website_action':
+   1. Use this tool whenever the user asks you to perform a website task (navigate to cart, checkout, homepage, shop with AI, order success page).
+   2. Always choose one supported action exactly: navigate_home, navigate_shop_ai, navigate_cart, navigate_checkout, navigate_order_success.
+   3. Return only the exact tool response.
 
 
 # Important

--- a/Backend/SpeechAssistant/server.py
+++ b/Backend/SpeechAssistant/server.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from flask import Flask, request
 from flask_cors import CORS
 from dotenv import load_dotenv
@@ -12,7 +13,7 @@ CORS(app)
 @app.route("/getToken")
 def get_token():
     name = request.args.get("name", "guest")
-    room = request.args.get("room", "default-room")
+    room = request.args.get("room") or f"room-{uuid.uuid4().hex[:10]}"
 
     token = (
         api.AccessToken(
@@ -34,5 +35,5 @@ def get_token():
 if __name__ == "__main__":
     app.run(
         host="0.0.0.0",
-        port=int(os.environ.get("PORT", 8080)),
+        port=int(os.environ.get("PORT", 5001)),
     )

--- a/Backend/SpeechAssistant/tools.py
+++ b/Backend/SpeechAssistant/tools.py
@@ -1,8 +1,5 @@
-import logging
-from livekit.agents import function_tool, RunContext
-import requests
+from livekit.agents import function_tool
 from livekit import agents
-from langchain_community.tools import DuckDuckGoSearchRun
 import json
 from memory import MemoryStore
 
@@ -210,3 +207,43 @@ def make_place_order(memory: MemoryStore):
 
 
     return place_order
+
+
+def make_website_action(memory: MemoryStore):
+    @function_tool(
+        description=(
+            "Perform website UI tasks such as navigation and checkout flow. "
+            "Supported actions: navigate_home, navigate_shop_ai, navigate_cart, "
+            "navigate_checkout, navigate_order_success."
+        )
+    )
+    async def website_action(context: agents.RunContext, action: str) -> str:
+        supported_actions = {
+            "navigate_home",
+            "navigate_shop_ai",
+            "navigate_cart",
+            "navigate_checkout",
+            "navigate_order_success",
+        }
+        normalized = action.strip().lower()
+        if normalized not in supported_actions:
+            return wrap_tool_output(
+                "website_action",
+                {
+                    "status": "error",
+                    "message": f"Unsupported action '{action}'.",
+                    "supported_actions": sorted(supported_actions),
+                },
+            )
+
+        memory.set("last_website_action", normalized)
+        return wrap_tool_output(
+            "website_action",
+            {
+                "status": "ok",
+                "action": normalized,
+                "message": f"Website action '{normalized}' prepared.",
+            },
+        )
+
+    return website_action

--- a/Backend/SpeechAssistant/tools.py
+++ b/Backend/SpeechAssistant/tools.py
@@ -31,16 +31,24 @@ def wrap_tool_output(tool_name: str, payload: dict) -> str:
 def make_search_products(memory: MemoryStore):
     @function_tool()
     async def search_products(context: agents.RunContext, query: str) -> str:
-        # Your search logic
+        if not query or not query.strip():
+            return wrap_tool_output(
+                "search_products",
+                {"message": "Please provide a product search query.", "products": []},
+            )
+
+        normalized_query = query.lower().strip()
         results = []
         for product in dummy_product_data:
-            if query.lower() in product['name'].lower() or query.lower() in product['description'].lower():
+            name = str(product.get("name", "")).lower()
+            description = str(product.get("description", "")).lower()
+            if normalized_query in name or normalized_query in description:
                 results.append(product)
         memory.set("last_product_search", results)
         if results:
             # return f"Search completed. Found {len(results)} products matching '{query}'."
             tool_payload = {
-                "message": f"Search completed. Found {len(results)} products matching '{query}'.",
+                "message": f"Search completed. Found {len(results)} products matching '{query.strip()}'.",
                 "products": [p["name"] for p in results]
             }
             # tool_output = f"```tool_outputs:search_products\n{json.dumps(tool_payload, indent=2)}\n```"
@@ -62,13 +70,14 @@ def make_list_top_search_results(memory: MemoryStore):
     async def list_top_search_results(context: agents.RunContext, max_items: int = 10) -> str:
         results = memory.get("last_product_search", [])
         if not results:
-            return "No recent search results found. Please perform a search first."
-        top_results = results[:max_items]
-        response = "Here are the top products from your search:\n"
-        for idx, product in enumerate(top_results, start=1):
-            response += f"{idx}. {product['name']}\n"
-        # return response.strip()
+            return wrap_tool_output(
+                "list_top_search_results",
+                {"message": "No recent search results found. Please perform a search first.", "top_results": []},
+            )
+        safe_max_items = max(1, min(max_items, 20))
+        top_results = results[:safe_max_items]
         tool_payload = {
+            "message": f"Here are the top {len(top_results)} products from your search.",
             "top_results": [product["name"] for product in top_results]
         }
         return wrap_tool_output("list_top_search_results", tool_payload)
@@ -84,7 +93,15 @@ def make_add_to_cart(memory: MemoryStore):
     async def add_to_cart(context: agents.RunContext, product_name: str, quantity: int = 1) -> str:
         search_results = memory.get("last_product_search", [])
         if not search_results:
-            return "No recent search results found. Please search for products first."
+            return wrap_tool_output(
+                "add_to_cart",
+                {"message": "No recent search results found. Please search for products first.", "cart": []},
+            )
+        if not product_name or not product_name.strip():
+            return wrap_tool_output(
+                "add_to_cart",
+                {"message": "Please provide a product name.", "cart": []},
+            )
 
         # Try to find the product by name (case-insensitive)
         matched_product = None
@@ -94,13 +111,20 @@ def make_add_to_cart(memory: MemoryStore):
                 break
 
         if not matched_product:
-            return f"No product named '{product_name}' found in the recent search results."
+            return wrap_tool_output(
+                "add_to_cart",
+                {
+                    "message": f"No product named '{product_name}' found in the recent search results.",
+                    "cart": [],
+                },
+            )
 
         # Add to cart with quantity
+        safe_quantity = max(1, quantity)
         cart = memory.get("cart", [])
         cart.append({
             "product": matched_product,
-            "quantity": quantity
+            "quantity": safe_quantity
         })
         memory.set("cart", cart)
         # return f"Added {quantity} x '{matched_product['name']}' to your cart successfully."
@@ -108,8 +132,9 @@ def make_add_to_cart(memory: MemoryStore):
         tool_payload = {
             "cart": [{
                 "name": matched_product["name"],
-                "quantity": quantity
-            }]
+                "quantity": safe_quantity
+            }],
+            "message": f"Added {safe_quantity} x '{matched_product['name']}' to your cart."
         }
         return wrap_tool_output("add_to_cart", tool_payload)
         # tool_output = f"```tool_outputs:add_to_cart\n{json.dumps(tool_payload, indent=2)}\n```"

--- a/Frontend/src/components/ShopWithAI.jsx
+++ b/Frontend/src/components/ShopWithAI.jsx
@@ -1,13 +1,12 @@
-import product1 from "../data/product1.json";
-import Header from "../components/Header";
-import { useParams } from "react-router-dom";
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import React, { useState, useEffect, useRef } from "react";
 import LiveKitModal from "../components/LivekitModal";
 import { FULL_PRODUCTS } from "../data/productsForAI"; // Adjust path
 import { useCart } from "./CartContext";
 
 const ShopWithAI = () => {
   const { addToCart } = useCart();
+  const navigate = useNavigate();
   const [messages, setMessages] = useState([
     {
       id: "1",
@@ -148,64 +147,63 @@ const ShopWithAI = () => {
 
   const handleAssistantMessage = (text) => {
     console.log("Assistant response recieved:", text);
-    if (text.startsWith("tool_outputs:add_to_cart")) {
+    const blocks = [
+      ...text.matchAll(/```tool_outputs:([a-z_]+)\n([\s\S]*?)```/g),
+    ].map((match) => ({
+      tool: match[1],
+      payload: match[2],
+    }));
+
+    const parsedByTool = {};
+    blocks.forEach((block) => {
       try {
-        const jsonStr = text.replace("tool_outputs:add_to_cart", "").trim();
-        const parsed = JSON.parse(jsonStr);
-        // parsed.cart.forEach((item) => {
-        //   addToCart(item);
-        // });
-
-        parsed.cart.forEach((item) => {
-          const matched = FULL_PRODUCTS.find((fp) =>
-            fp.name.toLowerCase().includes(item.name.toLowerCase())
-          );
-
-          if (matched) {
-            console.log("🛒 Adding to cart:", {
-              ...matched,
-              quantity: item.quantity,
-            });
-            addToCart({
-              ...matched,
-              quantity: item.quantity,
-            });
-          } else {
-            console.warn("Product not found in FULL_PRODUCTS:", item.name);
-          }
-        });
-      } catch (e) {
-        console.error("Failed to parse add_to_cart payload:", e);
+        parsedByTool[block.tool] = JSON.parse(block.payload);
+      } catch (error) {
+        console.error(`Failed to parse tool payload for ${block.tool}:`, error);
       }
-      return; // 🛑 Don't continue to product parsing for cart actions
+    });
+
+    const addToCartPayload = parsedByTool.add_to_cart;
+    if (addToCartPayload?.cart?.length) {
+      addToCartPayload.cart.forEach((item) => {
+        const matched = FULL_PRODUCTS.find((fp) =>
+          fp.name.toLowerCase().includes(item.name.toLowerCase())
+        );
+
+        if (matched) {
+          addToCart({
+            ...matched,
+            quantity: item.quantity,
+          });
+        }
+      });
     }
 
-    // Try to extract JSON tool_outputs from the assistant response
-    const toolOutputs = [
-      ...text.matchAll(/```tool_outputs\n([\s\S]*?)```/g),
-    ].map((match) => match[1]);
-
-    let products = [];
-    let productDetails = {};
-
-    if (toolOutputs.length >= 1) {
-      try {
-        const productList = JSON.parse(toolOutputs[0].replace(/'/g, '"'));
-        products = productList.products || [];
-      } catch (e) {
-        console.error("Failed to parse product list:", e);
+    const websiteActionPayload = parsedByTool.website_action;
+    if (websiteActionPayload?.status === "ok") {
+      const actionToRoute = {
+        navigate_home: "/",
+        navigate_shop_ai: "/shop-with-ai",
+        navigate_cart: "/cart",
+        navigate_checkout: "/checkout",
+        navigate_order_success: "/order-success",
+      };
+      const nextRoute = actionToRoute[websiteActionPayload.action];
+      if (nextRoute) {
+        navigate(nextRoute);
       }
     }
 
-    if (toolOutputs.length >= 2) {
-      try {
-        productDetails = JSON.parse(toolOutputs[1].replace(/'/g, '"'));
-      } catch (e) {
-        console.error("Failed to parse product details:", e);
-      }
-    }
+    const productListPayload = parsedByTool.search_products;
+    const topResultsPayload = parsedByTool.list_top_search_results;
+    const namesFromSearch = productListPayload?.products ?? [];
+    const namesFromTopResults = topResultsPayload?.top_results ?? [];
+    const combinedNames =
+      namesFromSearch.length > 0 ? namesFromSearch : namesFromTopResults;
 
-    const messageText = text.split("```")[0].trim(); // remove tool_output parts
+    const messageText = text
+      .replace(/```tool_outputs:[a-z_]+\n[\s\S]*?```/g, "")
+      .trim();
 
     //fixing the code from giving blank screen when products properties doesnt match
     // const finalProducts = products.map((name, index) => ({
@@ -221,7 +219,7 @@ const ShopWithAI = () => {
     //   quantity: productDetails[name]?.quantity || 1,
     // }));
 
-    const finalProducts = products
+    const finalProducts = combinedNames
       .map((p) => {
         const name = p.name || p; // support both [{name: "..."}] and ["..."]
         const matched = FULL_PRODUCTS.find((fp) =>
@@ -230,11 +228,8 @@ const ShopWithAI = () => {
         if (matched) {
           return {
             ...matched,
-            quantity: productDetails[name]?.quantity || 1,
-            description:
-              productDetails[name]?.description ||
-              matched.description ||
-              "No description",
+            quantity: 1,
+            description: matched.description || "No description",
           };
         }
         return null;

--- a/Frontend/src/components/SimpleVoiceAssistant.jsx
+++ b/Frontend/src/components/SimpleVoiceAssistant.jsx
@@ -8,7 +8,6 @@ import {
 import { Track } from "livekit-client";
 import { useEffect, useState } from "react";
 import "./SimpleVoiceAssistant.css";
-import { use } from "react";
 
 // const Message = ({ type, text }) => {
 //   return (


### PR DESCRIPTION
### Motivation
- Improve stability of the LiveKit voice assistant startup and token endpoint so voice sessions reliably connect from the frontend.
- Allow the speech assistant to request UI actions (navigation / checkout / cart) so spoken commands can trigger website behavior.
- Harden frontend handling of assistant tool output so structured tool responses are applied to the real UI (cart, navigation, product rendering).

### Description
- Make the token endpoint auto-generate a room when none is supplied and align the Flask default port to `5001` to match the frontend proxy (Backend/SpeechAssistant/server.py). 
- Connect the LiveKit job context before starting the agent session to stabilize startup ordering and register a new `website_action` tool in the assistant toolset (Backend/SpeechAssistant/agent.py and Backend/SpeechAssistant/tools.py).
- Add `website_action` backend tool that returns structured `tool_outputs:website_action` payloads for UI tasks and update prompts to instruct the agent to use it (Backend/SpeechAssistant/tools.py and Backend/SpeechAssistant/prompts.py).
- Update `ShopWithAI` frontend parsing to extract fenced `tool_outputs:<tool_name>` blocks, apply `add_to_cart` payloads to the real cart, execute `website_action` route navigation, and render search/list tool results correctly, and remove an unused import in `SimpleVoiceAssistant` (Frontend/src/components/ShopWithAI.jsx, Frontend/src/components/SimpleVoiceAssistant.jsx).

### Testing
- Compiled backend modules with `python3 -m py_compile Backend/SpeechAssistant/server.py Backend/SpeechAssistant/agent.py Backend/SpeechAssistant/tools.py Backend/SpeechAssistant/prompts.py` and the compile completed successfully.
- Built the frontend with `npm --prefix Frontend run build` and the Vite build completed successfully (only large-chunk warnings were reported, no build failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce95a1c66c83269f9ca8f5edc14ffd)